### PR TITLE
Stop "react/display-name" being enforced

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -154,7 +154,7 @@
     "quote-props": 0,
     "quotes": [2, "single", "avoid-escape"],
     "radix": 2,
-    "react/display-name": 2,
+    "react/display-name": 0,
     "react/jsx-boolean-value": 2,
     "react/jsx-no-undef": 2,
     "react/jsx-quotes": [2, "single", "avoid-escape"],


### PR DESCRIPTION
See https://github.com/feross/standard/issues/139 for discussion.
