### PR TITLE
Move `pkg.peerDependencies` to `pkg.dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,11 @@
   "bugs": {
     "url": "https://github.com/feross/eslint-config-standard/issues"
   },
-  "peerDependencies": {
+  "dependencies": {
     "eslint": "^1.0.0",
     "eslint-plugin-standard": "^1.1.0"
   },
   "devDependencies": {
-    "eslint": "^1.0.0",
-    "eslint-plugin-standard": "^1.1.0",
     "tape": "^4.0.0"
   },
   "homepage": "https://github.com/feross/eslint-config-standard",


### PR DESCRIPTION
`peerDependencies` are deprecated by `npm`, this is communicated via console warnings on `npm install`: 

```
npm WARN peerDependencies The peer dependency eslint@^1.0.0 included from eslint-config-standard will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm WARN peerDependencies The peer dependency eslint-plugin-standard@^1.1.0 included from eslint-config-standard will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm WARN peerDependencies The peer dependency eslint@^1.0.0 included from eslint-plugin-standard will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```

This PR moves the former `peerDependencies` `eslint` and `eslint-plugin-standard` and `devDependencies` to `dependencies`, doing away with the deprecation notice, making the module future proof and `npm@3` compatible.