### PR TITLE
Make test check for errorCount of 0

### DIFF
--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -8,6 +8,8 @@ test('load config in eslint to validate all rule syntax is correct', function (t
     configFile: 'eslintrc.json'
   })
 
-  t.ok(cli.executeOnText('var foo\n'))
+  var code = 'var foo = 1\nvar bar = function () {}\nbar(foo)\n'
+
+  t.ok(cli.executeOnText(code).errorCount === 0)
   t.end()
 })


### PR DESCRIPTION
The config validation code wasn't passing (`foo is defined but never used`) so I added code to make it pass and made the test check that `errorCount === 0`.