### PR TITLE
Add Promise param name rule 

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -125,6 +125,8 @@
     "wrap-iife": [2, "any"],
     "yoda": [2, "never"],
 
+    "promiseparams/promiseparams": 2,
+
     "standard/object-curly-even-spacing": [2, "either"],
     "standard/array-bracket-even-spacing": [2, "either"],
     "standard/computed-property-even-spacing": [2, "even"]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/feross/eslint-config-standard/issues"
   },
   "peerDependencies": {
+    "eslint-plugin-promiseparams": "^1.0.7",
     "eslint-plugin-standard": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
From https://github.com/feross/standard/issues/282

- adds https://github.com/jden/eslint-plugin-promiseparams to enforce Promise parameter names