### PR TITLE
object-curly-spacing

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -104,6 +104,7 @@
     "no-unused-vars": [2, { "vars": "all", "args": "none" }],
     "no-useless-call": 2,
     "no-with": 2,
+    "object-curly-spacing": [2, "always"],
     "one-var": [2, { "initialized": "never" }],
     "operator-linebreak": [2, "after", { "overrides": { "?": "before", ":": "before" } }],
     "padded-blocks": [2, "never"],


### PR DESCRIPTION
Require a space at the start and end of objects.
Valid:
```js
var obj = {};
var obj = { 'foo': 'bar' };
var obj = { 'foo': { 'bar': 'baz' }, 'qux': 'quxx' };
var obj = {
  'foo': 'bar'
};
var { x } = y;
import { foo } from 'bar';
```

Invalid
```js
var obj = {'foo': 'bar'};
var obj = {'foo': 'bar' };
var obj = { baz: {'foo': 'qux'}, bar};
var obj = {baz: { 'foo': 'qux' }, bar};
var obj = {'foo': 'bar'
};
var obj = {
  'foo':'bar'};
var {x} = y;
import {foo } from 'bar';
```