### PR TITLE
Allow dangle comma on multiline objects and arrays

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -30,7 +30,7 @@
     "arrow-spacing": [2, { "before": true, "after": true }],
     "block-spacing": [2, "always"],
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],
-    "comma-dangle": [2, "never"],
+    "comma-dangle": [2, "only-multiline"],
     "comma-spacing": [2, { "before": false, "after": true }],
     "comma-style": [2, "last"],
     "constructor-super": 2,


### PR DESCRIPTION
This configuration option was added on eslint 2.0 and lets use the dangle comma on objects and arrays. This produces cleaner diffs, makes easier to move lines up and down in text editors and is backwards compatible since it is only relaxing a rule. It doesn't make mandatory the dangle comma on multiline nodes, but it allows it.