### PR TITLE
Removed "arrow-parens" rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -26,7 +26,6 @@
 
   "rules": {
     "accessor-pairs": 2,
-    "arrow-parens": [2, "always"],
     "arrow-spacing": [2, { "before": true, "after": true }],
     "block-spacing": [2, "always"],
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],


### PR DESCRIPTION
From: https://github.com/feross/standard/issues/414