### PR TITLE
Update eslint version to ^2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/feross/eslint-config-standard/issues"
   },
   "devDependencies": {
-    "eslint": "^2.1.0",
+    "eslint": "^2.5.0",
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-standard": "^1.3.1",
     "tape": "^4.0.0"


### PR DESCRIPTION
The rules 'no-duplicate-import' and 'no-useless-escape' that were added 4 days [ago](https://github.com/feross/eslint-config-standard/commit/4fd4c529c86037c22026319b55578584262df850), require a minimum version of eslint 2.5.0.  This introduced a breaking change in the 5.2.0 release for anyone with an eslint version < 2.5.0