### PR TITLE
Remove unneeded config for ecmaVersion

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,6 +1,5 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6,
     "ecmaFeatures": {
       "experimentalObjectRestSpread": true,
       "jsx": true


### PR DESCRIPTION
`parserOptions.ecmaVersion`is set to 6 by ESLint when `es6` environment is used, cf.
https://github.com/eslint/eslint/blob/master/conf/environments.js#L98