### PR TITLE
Replace t.ok with t.equal

### DIFF
--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -11,6 +11,6 @@ test('load config in eslint to validate all rule syntax is correct', function (t
 
   var code = 'var foo = 1\nvar bar = function () {}\nbar(foo)\n'
 
-  t.ok(cli.executeOnText(code).errorCount === 0)
+  t.equal(cli.executeOnText(code).errorCount, 0)
   t.end()
 })


### PR DESCRIPTION
While `t.strictEqual` would preserve the exact behaviour, `t.equal` gets the same result for Numbers, and is more concise imho.