### PR TITLE
Disallow nested ternary expressions (no-nested-ternary)

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -85,6 +85,7 @@
     "no-multiple-empty-lines": [2, { "max": 1 }],
     "no-native-reassign": 2,
     "no-negated-in-lhs": 2,
+    "no-nested-ternary": 2,
     "no-new": 2,
     "no-new-func": 2,
     "no-new-object": 2,


### PR DESCRIPTION
Nested ternary expressions makes code quite hard to understand, so they probably should be disallowed.