### PR TITLE
add arrow-parens as-needed with requireForBlockBody

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -27,6 +27,7 @@
   "rules": {
     "accessor-pairs": 2,
     "arrow-spacing": [2, { "before": true, "after": true }],
+    "arrow-parens": [2, "as-needed", { "requireForBlockBody": true }],
     "block-spacing": [2, "always"],
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],
     "camelcase": [2, { "properties": "never" }],


### PR DESCRIPTION
Ref: http://eslint.org/docs/rules/arrow-parens#as-needed

``` js
/*eslint arrow-parens: [2, "as-needed", { "requireForBlockBody": true }]*/
/*eslint-env es6*/

(a) => {};
(a) => {'\n'};
a => ({});
() => {};
a => a;
a.then((foo) => {});
a.then((foo) => { if (true) {}; });
a((foo) => { if (true) {}; });
(a, b, c) => a;
(a = 10) => a;
([a, b]) => a;
({a, b}) => a;
```

Compatible with `--fix`.

Adheres to what I believe we were after:
> I think? the only rule we wanted here was: must have parens for multi-line lambda (that isn't to say that rule exists though)

But adds the rule that if a block body is included in the single line, it must too have parens (I'm OK with that!).

Related:
https://github.com/feross/standard/issues/414
https://github.com/feross/eslint-config-standard/pull/54
https://github.com/timoxley/standard-loader/issues/68
https://github.com/feross/standard/issues?utf8=%E2%9C%93&q=arrow-parens