### PR TITLE
Add no-console rule.

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -49,6 +49,7 @@
     "no-caller": 2,
     "no-class-assign": 2,
     "no-cond-assign": 2,
+    "no-console": 0,
     "no-const-assign": 2,
     "no-constant-condition": [2, { "checkLoops": false }],
     "no-control-regex": 2,


### PR DESCRIPTION
This sets `no-console` rule to 0.

>  If you are developing for Node.js then you most likely do not want this rule enabled.

http://eslint.org/docs/rules/no-console#when-not-to-use-it

