### PR TITLE
Remove deprecated no-native-reassign rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -83,7 +83,6 @@
     "no-multi-spaces": 2,
     "no-multi-str": 2,
     "no-multiple-empty-lines": [2, { "max": 1 }],
-    "no-native-reassign": 2,
     "no-negated-in-lhs": 2,
     "no-new": 2,
     "no-new-func": 2,


### PR DESCRIPTION
The replacement rule "no-global-assign" is already enabled.

Fix https://github.com/feross/standard/issues/731