### PR TITLE
relax rule "no-extra-label"

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -67,7 +67,6 @@
     "no-extend-native": "error",
     "no-extra-bind": "error",
     "no-extra-boolean-cast": "error",
-    "no-extra-label": "error",
     "no-extra-parens": ["error", "functions"],
     "no-fallthrough": "error",
     "no-floating-decimal": "error",


### PR DESCRIPTION
This rule is redundant, since we already enable "no-labels" which is
more restrictive.