### PR TITLE
Add `eslint-plugin-node` to Usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ official ESLint website.
 To use the JavaScript Standard Style shareable config, first run this:
 
 ```bash
-npm install --save-dev eslint-config-standard eslint-plugin-standard eslint-plugin-promise eslint-plugin-import
+npm install --save-dev eslint-config-standard eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node
 ```
 
 Then, add this to your .eslintrc file:


### PR DESCRIPTION
Update documentation to add `eslint-plugin-node` to the Usage documentation, as `node` is specified as a plugin in `eslintrc.json` but is missing from the documentation.