### PR TITLE
Update eslint-plugin-standard to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^2.2.0",
+    "eslint-plugin-standard": "^3.0.0",
     "tape": "^4.6.3"
   },
   "homepage": "https://github.com/feross/eslint-config-standard",
@@ -52,7 +52,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^2.2.0"
+    "eslint-plugin-standard": "^3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We updated both `eslint-config-standard` and `eslint-plugin-standard` to the latest versions and unfortunately this doesn't work with npm 2 (Node.js 4) as `eslint-config-standard` has a peerDependency on [`eslint-plugin-standard@^2.2.0`](https://github.com/feross/eslint-config-standard/blob/9b1df3a0c5f338dfaafd33b817f22b385f397b8f/package.json#L55).

This should fix the issue.